### PR TITLE
Changes in Reducer module

### DIFF
--- a/Data/Generator.hs
+++ b/Data/Generator.hs
@@ -60,7 +60,7 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import Control.Parallel.Strategies (rseq, parMap)
 import Data.Foldable (fold,foldMap)
-import Data.Semigroup.Reducer
+import Data.Semigroup.Reducer (Reducer(..))
 
 -- | minimal definition 'mapReduce' or 'mapTo'
 class Generator c where

--- a/Data/Semigroup/Generator.hs
+++ b/Data/Semigroup/Generator.hs
@@ -31,7 +31,7 @@ module Data.Semigroup.Generator
 import Data.List.NonEmpty
 import Data.Semigroup (Semigroup(..)) -- , WrappedMonoid(..))
 import Data.Semigroup.Foldable
-import Data.Semigroup.Reducer
+import Data.Semigroup.Reducer (Reducer(..))
 import Data.Generator
 
 -- | minimal definition 'mapReduce1' or 'mapTo1'


### PR DESCRIPTION
Renamed some Reducer functions to mapReduce style and enhanced their implementation (subject to discussion, since I haven't tested the performance). Thus, with Reducer + Data.Foldable imports we don't need Generator to do efficient mapReduce.

Added mapReduce-like functions working with Maybe values, generalising methods from Data.Maybe.

Also, see the comment to commit.
