### PR TITLE
give a default implementation for unit

### DIFF
--- a/src/Data/Semigroup/Reducer.hs
+++ b/src/Data/Semigroup/Reducer.hs
@@ -75,6 +75,7 @@ class Semigroup m => Reducer c m where
 
   snoc m = (<>) m . unit
   cons = (<>) . unit
+  unit = snoc mempty
 
 -- | Apply a 'Reducer' to a 'Foldable' container, after mapping the contents into a suitable form for reduction.
 foldMapReduce :: (Foldable f, Monoid m, Reducer e m) => (a -> e) -> f a -> m


### PR DESCRIPTION
The docs claim snoc is a perfectly good minimal definition, but unit isn't defined if you try that.
