### PR TITLE
Fix building with base-4.8.0.0

### DIFF
--- a/src/Data/Generator.hs
+++ b/src/Data/Generator.hs
@@ -3,6 +3,9 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Generator
@@ -35,7 +38,9 @@ module Data.Generator
   , reduceWith
   ) where
 
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid (Monoid, mappend, mempty)
+#endif
 
 import Data.Array
 import Data.Text (Text)
@@ -62,7 +67,10 @@ import Data.Map (Map)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 -- import Control.Parallel.Strategies (rseq, parMap)
-import Data.Foldable (fold,foldMap)
+import Data.Foldable (fold)
+#if !(MIN_VERSION_base(4,8,0))
+import Data.Foldable (foldMap)
+#endif
 import Data.Semigroup.Reducer
 
 -- | minimal definition 'mapReduce' or 'mapTo'

--- a/src/Data/Generator/Combinators.hs
+++ b/src/Data/Generator/Combinators.hs
@@ -4,6 +4,9 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Generator.Combinators
@@ -53,11 +56,16 @@ module Data.Generator.Combinators
 import Prelude hiding
   ( mapM_, any, all, elem, filter, concatMap, and, or
   , sum, product, notElem, replicate, cycle, repeat
+#if MIN_VERSION_base(4,8,0)
+  , foldMap
+#endif
   )
 import Control.Applicative
 import Control.Monad (MonadPlus)
 import Data.Generator
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid (Monoid(..))
+#endif
 import Data.Semigroup (Sum(..), Product(..), All(..), Any(..), WrappedMonoid(..))
 import Data.Semigroup.Applicative (Traversal(..))
 import Data.Semigroup.Alternative (Alternate(..))

--- a/src/Data/Semigroup/Alt.hs
+++ b/src/Data/Semigroup/Alt.hs
@@ -4,6 +4,9 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Semigroup.Alt
@@ -22,7 +25,9 @@ module Data.Semigroup.Alt
     ) where
 
 import Data.Functor.Plus
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid (Monoid(..))
+#endif
 import Data.Semigroup (Semigroup(..))
 import Data.Semigroup.Reducer (Reducer(..))
 

--- a/src/Data/Semigroup/Alternative.hs
+++ b/src/Data/Semigroup/Alternative.hs
@@ -4,6 +4,9 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Semigroup.Alternative
@@ -22,7 +25,9 @@ module Data.Semigroup.Alternative
     ) where
 
 import Control.Applicative
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid (Monoid(..))
+#endif
 import Data.Semigroup (Semigroup(..))
 import Data.Semigroup.Reducer (Reducer(..))
 

--- a/src/Data/Semigroup/Applicative.hs
+++ b/src/Data/Semigroup/Applicative.hs
@@ -4,6 +4,9 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Semigroup.Applicative
@@ -23,7 +26,9 @@ module Data.Semigroup.Applicative
     ) where
 
 import Control.Applicative
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid (Monoid(..))
+#endif
 import Data.Semigroup (Semigroup(..))
 import Data.Semigroup.Reducer (Reducer(..))
 

--- a/src/Data/Semigroup/Monad.hs
+++ b/src/Data/Semigroup/Monad.hs
@@ -4,6 +4,9 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Semigroup.Monad
@@ -23,8 +26,10 @@ module Data.Semigroup.Monad
     ) where
 
 import Control.Monad (liftM, liftM2)
+#if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative (Applicative(..))
 import Data.Monoid (Monoid(..))
+#endif
 import Data.Semigroup (Semigroup(..))
 import Data.Semigroup.Reducer (Reducer(..))
 

--- a/src/Data/Semigroup/MonadPlus.hs
+++ b/src/Data/Semigroup/MonadPlus.hs
@@ -4,6 +4,9 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Semigroup.MonadPlus
@@ -22,8 +25,11 @@ module Data.Semigroup.MonadPlus
     ) where
 
 import Control.Monad (MonadPlus(..))
-import Control.Applicative (Applicative(..),Alternative(..))
+import Control.Applicative (Alternative(..))
+#if !(MIN_VERSION_base(4,8,0))
+import Control.Applicative (Alternative(..))
 import Data.Monoid (Monoid(..))
+#endif
 import Data.Semigroup (Semigroup(..))
 import Data.Semigroup.Reducer (Reducer(..))
 

--- a/src/Data/Semigroup/MonadPlus.hs
+++ b/src/Data/Semigroup/MonadPlus.hs
@@ -27,7 +27,7 @@ module Data.Semigroup.MonadPlus
 import Control.Monad (MonadPlus(..))
 import Control.Applicative (Alternative(..))
 #if !(MIN_VERSION_base(4,8,0))
-import Control.Applicative (Alternative(..))
+import Control.Applicative (Applicative(..))
 import Data.Monoid (Monoid(..))
 #endif
 import Data.Semigroup (Semigroup(..))

--- a/src/Data/Semigroup/Reducer.hs
+++ b/src/Data/Semigroup/Reducer.hs
@@ -3,6 +3,9 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Semigroup.Reducer
@@ -25,14 +28,18 @@ module Data.Semigroup.Reducer
   , Count(..)
   ) where
 
+#if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative
+#endif
 
 import qualified Data.Monoid as Monoid
 import Data.Semigroup as Semigroup
 import Data.Semigroup.Foldable
 import Data.Semigroup.Instances ()
 import Data.Hashable
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Foldable
+#endif
 import Data.FingerTree
 
 import qualified Data.Sequence as Seq

--- a/src/Data/Semigroup/Reducer/With.hs
+++ b/src/Data/Semigroup/Reducer/With.hs
@@ -4,6 +4,9 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Semigroup.Reducer.With
@@ -21,10 +24,12 @@ module Data.Semigroup.Reducer.With
 
 import Control.Applicative
 import Data.FingerTree
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Foldable
 import Data.Traversable
-import Data.Hashable
 import Data.Monoid
+#endif
+import Data.Hashable
 import Data.Semigroup.Reducer
 import Data.Semigroup.Foldable
 import Data.Semigroup.Traversable

--- a/src/Data/Semigroup/Self.hs
+++ b/src/Data/Semigroup/Self.hs
@@ -4,6 +4,9 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Semigroup.Self
@@ -27,8 +30,10 @@ module Data.Semigroup.Self
     )  where
 
 import Control.Applicative
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Foldable
 import Data.Traversable
+#endif
 import Data.Semigroup
 import Data.Semigroup.Foldable
 import Data.Semigroup.Traversable

--- a/src/Data/Semigroup/Union.hs
+++ b/src/Data/Semigroup/Union.hs
@@ -3,6 +3,10 @@
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
+
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
 module Data.Semigroup.Union
     ( module Data.Semigroup.Reducer
     -- * Unions of Containers
@@ -37,8 +41,10 @@ import qualified Data.List as List
 
 import Data.Hashable
 import Data.Functor
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Foldable
 import Data.Traversable
+#endif
 import Data.Semigroup
 import Data.Semigroup.Foldable
 import Data.Semigroup.Traversable


### PR DESCRIPTION
This commit adds some CPP pragmas to get around some import conflicts and warnings that arise from `Prelude` exporting `Monoid(..)`, `Applicative(..)`, `Foldable(..)`, and `Traversable(..)` in `base-4.8.0.0`.

Note that GHC 7.10 also warns that some trustworthy modules are actualy safe, but I'm not sure if this holds for all versions of GHC, so I'll refrain from changing them from trustworthy.