### PR TITLE
Fix the build with fingertree-0.1.2 and later

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,10 @@
+next
+----
+* Fix the build with `fingertree-0.1.2` or later. Since `fingertree-0.1.2` now
+  provides a `Semigroup` instance for `FingerTree`, as a result
+  `Data.Semigroup.Instances` no longer exports anything if building against
+  `fingertree-0.1.2` or later with `base-4.9` or later.
+
 3.12.2
 ------
 * Removed a couple of redundant instance constraints

--- a/src/Data/Semigroup/Instances.hs
+++ b/src/Data/Semigroup/Instances.hs
@@ -5,8 +5,10 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Semigroup.Instances where
 
+#if !(MIN_VERSION_fingertree(0,1,2) || MIN_VERSION_base(4,9,0))
 import Data.FingerTree
 import Data.Semigroup
 
 instance Measured v a => Semigroup (FingerTree v a) where
   (<>) = mappend
+#endif


### PR DESCRIPTION
`fingertree-0.1.2` now provides a `Semigroup` instance for `FingerTree`, so `Data.Semigroup.Instances` fails to compile as a result. This PR works around the issue with some tactical CPP.

Addresses https://github.com/fpco/stackage/issues/2920.