### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/reducers.cabal
+++ b/reducers.cabal
@@ -44,8 +44,11 @@ library
     hashable               >= 1.1.2.1  && < 1.4,
     text                   >= 0.11.1.5 && < 1.3,
     unordered-containers   >= 0.2      && < 0.3,
-    semigroups             >= 0.9      && < 1,
     semigroupoids          >= 4        && < 6
+
+  if impl(ghc < 8.0)
+    build-depends:
+      semigroups           >= 0.9      && < 1
 
   exposed-modules:
     Data.Generator


### PR DESCRIPTION
It is not needed on newer GHC.